### PR TITLE
Re-export scoring utilities as kurenai.scoring

### DIFF
--- a/src/kurenai/scoring.py
+++ b/src/kurenai/scoring.py
@@ -1,0 +1,21 @@
+"""Re-export of ``rouge_score.scoring``.
+
+This module lets users write ``from kurenai.scoring import Score``
+instead of mixing ``rouge_score`` and ``kurenai`` imports.
+"""
+
+from __future__ import annotations
+
+from rouge_score.scoring import AggregateScore as AggregateScore
+from rouge_score.scoring import BaseScorer as BaseScorer
+from rouge_score.scoring import BootstrapAggregator as BootstrapAggregator
+from rouge_score.scoring import Score as Score
+from rouge_score.scoring import fmeasure as fmeasure
+
+__all__ = [
+    "Score",
+    "AggregateScore",
+    "BootstrapAggregator",
+    "BaseScorer",
+    "fmeasure",
+]

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -1,0 +1,41 @@
+from rouge_score import scoring as original_scoring
+
+from kurenai import scoring
+from kurenai.rouge_scorer import RougeScorer
+
+
+class TestReExport:
+    def test_score(self) -> None:
+        assert scoring.Score is original_scoring.Score
+
+    def test_aggregate_score(self) -> None:
+        assert scoring.AggregateScore is original_scoring.AggregateScore
+
+    def test_bootstrap_aggregator(self) -> None:
+        assert (
+            scoring.BootstrapAggregator is original_scoring.BootstrapAggregator
+        )
+
+    def test_base_scorer(self) -> None:
+        assert scoring.BaseScorer is original_scoring.BaseScorer
+
+    def test_fmeasure(self) -> None:
+        assert scoring.fmeasure is original_scoring.fmeasure
+
+
+class TestBootstrapAggregatorIntegration:
+    def test_aggregate_with_kurenai_rouge_scorer(self) -> None:
+        scorer = RougeScorer(["rouge1"])
+        aggregator = scoring.BootstrapAggregator()
+
+        aggregator.add_scores(scorer.score("テスト いち に", "テスト に"))
+        aggregator.add_scores(scorer.score("テスト いち", "テスト いち に"))
+
+        result = aggregator.aggregate()
+
+        assert "rouge1" in result
+        for aggregate_score in result.values():
+            assert isinstance(aggregate_score, scoring.AggregateScore)
+            assert isinstance(aggregate_score.low, scoring.Score)
+            assert isinstance(aggregate_score.mid, scoring.Score)
+            assert isinstance(aggregate_score.high, scoring.Score)


### PR DESCRIPTION
## 概要

`rouge_score.scoring` の主要なシンボル（`Score`, `AggregateScore`, `BootstrapAggregator`, `BaseScorer`, `fmeasure`）を再エクスポートする新規モジュール `kurenai.scoring` を追加しました。実体は re-export のみで、ロジックの再実装はしていません。

## 目的（kurenai 完結の import）

これまでは `kurenai.rouge_scorer.RougeScorer` は kurenai 側からimportできる一方、スコアの集計に使う `BootstrapAggregator` などは `rouge_score.scoring` から直接importする必要があり、`rouge_score` と `kurenai` の import が混在していました。

```python
# Before
from rouge_score.scoring import BootstrapAggregator, Score
from kurenai.rouge_scorer import RougeScorer

# After
from kurenai.scoring import BootstrapAggregator, Score
from kurenai.rouge_scorer import RougeScorer
```

`kurenai` の import だけで完結できるようにすることが目的です。

## テスト内容

`tests/test_scoring.py` を新規追加しました。

- `kurenai.scoring` の各シンボル（`Score`, `AggregateScore`, `BootstrapAggregator`, `BaseScorer`, `fmeasure`）が `rouge_score.scoring` の同名オブジェクトと `is` で同一であることを確認するテスト
- 統合テスト: `kurenai.rouge_scorer.RougeScorer(["rouge1"]).score()` の結果を複数回 `BootstrapAggregator.add_scores()` に渡して `aggregate()` し、返り値の各値が `AggregateScore` インスタンスであり、`.low` / `.mid` / `.high` が `Score` であることを検証

## 確認方法

```
python3 -m venv .venv
.venv/bin/pip install -e ".[dev]"
.venv/bin/task test
```

format（black -l 79 ほか）→ `pytest -v --doctest-modules` → flake8 + mypy がすべて通ることを確認済みです（15 passed, no lint/type issues）。

## 制約事項

- README.md、IMPLEMENTATION_PLAN.md、`src/kurenai/rouge_scorer.py`、バージョン番号は変更していません（別タスクの担当範囲のため）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)