### PR TITLE
Support rougeLsum

### DIFF
--- a/src/kurenai/rouge_scorer.py
+++ b/src/kurenai/rouge_scorer.py
@@ -19,7 +19,7 @@ RougeType = Literal[
     "rouge8",
     "rouge9",
     "rougeL",
-    # "rougeLsum",  # TODO
+    "rougeLsum",
 ]
 
 
@@ -34,6 +34,7 @@ class RougeScoreDict(TypedDict, total=False):
     rouge8: Score
     rouge9: Score
     rougeL: Score
+    rougeLsum: Score
 
 
 class RougeScorer(BaseScorer):
@@ -51,6 +52,9 @@ class RougeScorer(BaseScorer):
         Valid rouge types that can be computed are:
             rougeN (e.g. rouge1, rouge2, ..., rouge9): n-gram based scoring.
             rougeL: Longest common subsequence based scoring.
+            rougeLsum: Summary-level longest common subsequence based
+                scoring. Sentences are assumed to be separated by newlines;
+                each sentence is tokenized independently before scoring.
 
         Args:
             rouge_types: An iterable of rouge types to calculate.

--- a/tests/test_kurenai.py
+++ b/tests/test_kurenai.py
@@ -81,6 +81,41 @@ class TestRougeScorer:
                 }
                 assert actual == expected
 
+            def test_rougeLsum_single_line_matches_rougeL(self) -> None:
+                # 改行を含まない1文だけの入力では、rougeLsumはrougeLと一致する
+                scorer = RougeScorer(["rougeL", "rougeLsum"])
+                actual = scorer.score("テスト いち に", "テスト いち")
+
+                precision = 2 / 2
+                recall = 2 / 3
+                fscore = fscore_helper(precision, recall)
+                expected = {
+                    "rougeL": Score(precision, recall, fscore),
+                    "rougeLsum": Score(precision, recall, fscore),
+                }
+                assert actual == expected
+
+            def test_rougeLsum(self) -> None:
+                # ref: https://github.com/google-research/google-research/blob/c34656f25265e717cc7f051a99185594892fd041/rouge/rouge_scorer_test.py#L271-L276  # NOQA: E501
+                # 改行区切りで複数文を渡すと、文ごとのLCSの和集合でsummary-levelに
+                # スコアリングされる
+                scorer = RougeScorer(["rougeLsum"])
+                actual = scorer.score(
+                    "あ い う え お", "あ い か き く\nあ う く け お"
+                )
+
+                # target: あ い う え お (5トークン)
+                # prediction 1文目: あ い か き く / 2文目: あ う く け お
+                #   (計10トークン)
+                # 1文目とのLCS: 「あ い」(2)
+                # 2文目とのLCS: 「あ う ... お」の「あ」「う」「お」(3)
+                # 和集合（重複除く）: 「あ」「い」「う」「お」の4トークンがhit
+                precision = 4 / 10
+                recall = 4 / 5
+                fscore = fscore_helper(precision, recall)
+                expected = {"rougeLsum": Score(precision, recall, fscore)}
+                assert actual == expected
+
         class TestScoreMulti:
             def test_rouge1(self) -> None:
                 scorer = RougeScorer(["rouge1"])


### PR DESCRIPTION
## 概要

`rouge_score.rouge_scorer.RougeScorer` が既にサポートしている `rougeLsum`（summary-level LCS スコア）を kurenai でも利用できるようにしました。実装計画の 1-1 に対応します。

## 実装方針

- `src/kurenai/rouge_scorer.py` の `RougeType` Literal に `"rougeLsum"` を追加（`# "rougeLsum",  # TODO` コメントを置き換え）
- `RougeScoreDict` TypedDict に `rougeLsum: Score` を追加
- `__init__` の docstring に、rougeLsum が改行区切りの文単位で summary-level LCS スコアを計算することを追記

本家 `RougeScorer` は `split_summaries=False`（デフォルト）で `rougeLsum` をサポート済みで、改行区切りを1文とみなし、kurenai が渡す `AllCharacterSupportTokenizer` で各文をトークナイズします。そのため kurenai 側では**スコア計算ロジックを一切再実装せず**、型定義を通すだけで動作します。委譲ベースの薄いラッパーというこれまでの設計方針を踏襲しています。

## テスト内容

`tests/test_kurenai.py` の `TestNonAscii.TestScore` に以下を追加:

- `test_rougeLsum`: 本家 `rouge_scorer_test.py` の `testRougeLsum`（[該当箇所](https://github.com/google-research/google-research/blob/c34656f25265e717cc7f051a99185594892fd041/rouge/rouge_scorer_test.py#L271-L276)）を、日本語の分かち書き済み・複数行テキストに翻案。期待値（precision/recall/fmeasure）は手計算で記述
- `test_rougeLsum_single_line_matches_rougeL`: 改行を含まない1文だけの入力では `rougeLsum` と `rougeL` が一致することを確認

実装前に本家の挙動を Python REPL で実際に実行し、期待値を確認してから記述しました（推測で書いていません）。

## 確認方法

```
.venv/bin/task test
```

`format` → `pytest -v --doctest-modules` → `flake8` + `mypy` がすべて通ることを確認済みです（11 tests passed）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)