### PR TITLE
Add CLI (python -m kurenai)

### DIFF
--- a/src/kurenai/__main__.py
+++ b/src/kurenai/__main__.py
@@ -1,0 +1,204 @@
+"""Command line interface for kurenai.
+
+Sample usage:
+
+    python -m kurenai --rouge-types rouge1,rouge2,rougeL \\
+        --target-file targets.txt --prediction-file predictions.txt \\
+        --use-aggregator --output scores.csv
+
+Both ``--target-file`` and ``--prediction-file`` are expected to be
+newline-delimited text files where one line corresponds to one record.
+
+Note:
+    Tokenizer selection (e.g. a Japanese morphological tokenizer) is not
+    yet configurable from this CLI. ``kurenai.rouge_scorer.RougeScorer``
+    always uses ``AllCharacterSupportTokenizer``. Support for pluggable
+    tokenizers is planned for a later phase.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import IO, cast, get_args
+
+from kurenai.rouge_scorer import RougeScoreDict, RougeScorer, RougeType
+from kurenai.scoring import AggregateScore, BootstrapAggregator, Score
+
+_VALID_ROUGE_TYPES: tuple[str, ...] = get_args(RougeType)
+_DEFAULT_ROUGE_TYPES = "rouge1,rouge2,rougeL"
+
+
+def _parse_rouge_types(value: str) -> list[str]:
+    rouge_types = [item.strip() for item in value.split(",") if item.strip()]
+    invalid_types = [t for t in rouge_types if t not in _VALID_ROUGE_TYPES]
+    if invalid_types:
+        raise argparse.ArgumentTypeError(
+            "invalid rouge type(s): {}. Valid types are: {}".format(
+                ", ".join(invalid_types), ", ".join(_VALID_ROUGE_TYPES)
+            )
+        )
+    return rouge_types
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m kurenai",
+        description=(
+            "Calculate ROUGE scores between a target file and a "
+            "prediction file."
+        ),
+    )
+    parser.add_argument(
+        "--rouge-types",
+        type=_parse_rouge_types,
+        default=_parse_rouge_types(_DEFAULT_ROUGE_TYPES),
+        help=(
+            "Comma-separated list of ROUGE types to calculate. Valid "
+            "values: {}. (default: {})".format(
+                ", ".join(_VALID_ROUGE_TYPES), _DEFAULT_ROUGE_TYPES
+            )
+        ),
+    )
+    parser.add_argument(
+        "--target-file",
+        required=True,
+        type=Path,
+        help="Newline-delimited file containing target text.",
+    )
+    parser.add_argument(
+        "--prediction-file",
+        required=True,
+        type=Path,
+        help="Newline-delimited file containing prediction text.",
+    )
+    parser.add_argument(
+        "--use-aggregator",
+        action="store_true",
+        help="Aggregate scores with BootstrapAggregator.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="File to write the CSV output to. Defaults to stdout.",
+    )
+    return parser
+
+
+def _read_records(path: Path) -> list[str]:
+    return path.read_text(encoding="utf-8").splitlines()
+
+
+def _compute_scores(
+    rouge_types: list[RougeType],
+    targets: list[str],
+    predictions: list[str],
+) -> list[RougeScoreDict]:
+    scorer = RougeScorer(rouge_types)
+    return [
+        scorer.score(target, prediction)
+        for target, prediction in zip(targets, predictions)
+    ]
+
+
+def _write_scores_csv(scores: list[RougeScoreDict], output: IO[str]) -> None:
+    """Writes per-example scores, following rouge_score's io.py format."""
+    if not scores:
+        return
+    rouge_types = sorted(scores[0].keys())
+
+    output.write("id")
+    for rouge_type in rouge_types:
+        output.write(",{t}-P,{t}-R,{t}-F".format(t=rouge_type))
+    output.write("\n")
+    for i, result in enumerate(scores):
+        output.write(str(i))
+        result_by_type = cast("dict[str, Score]", result)
+        for rouge_type in rouge_types:
+            score = result_by_type[rouge_type]
+            output.write(
+                ",{:.6f},{:.6f},{:.6f}".format(
+                    score.precision, score.recall, score.fmeasure
+                )
+            )
+        output.write("\n")
+
+
+def _write_aggregates_csv(
+    aggregates: dict[str, AggregateScore], output: IO[str]
+) -> None:
+    """Writes aggregate scores, following rouge_score's io.py format."""
+    output.write("score_type,low,mid,high\n")
+    for score_type, aggregate in sorted(aggregates.items()):
+        output.write(
+            "{t}-R,{low:.6f},{mid:.6f},{high:.6f}\n".format(
+                t=score_type,
+                low=aggregate.low.recall,
+                mid=aggregate.mid.recall,
+                high=aggregate.high.recall,
+            )
+        )
+        output.write(
+            "{t}-P,{low:.6f},{mid:.6f},{high:.6f}\n".format(
+                t=score_type,
+                low=aggregate.low.precision,
+                mid=aggregate.mid.precision,
+                high=aggregate.high.precision,
+            )
+        )
+        output.write(
+            "{t}-F,{low:.6f},{mid:.6f},{high:.6f}\n".format(
+                t=score_type,
+                low=aggregate.low.fmeasure,
+                mid=aggregate.mid.fmeasure,
+                high=aggregate.high.fmeasure,
+            )
+        )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    try:
+        args = parser.parse_args(argv)
+    except SystemExit as exc:
+        return exc.code if isinstance(exc.code, int) else 1
+
+    targets = _read_records(args.target_file)
+    predictions = _read_records(args.prediction_file)
+
+    if len(targets) != len(predictions):
+        print(
+            "Error: --target-file and --prediction-file must have the "
+            "same number of lines (target: {}, prediction: {}).".format(
+                len(targets), len(predictions)
+            ),
+            file=sys.stderr,
+        )
+        return 1
+
+    scores = _compute_scores(args.rouge_types, targets, predictions)
+
+    if args.use_aggregator:
+        aggregator = BootstrapAggregator()
+        for score in scores:
+            aggregator.add_scores(score)
+        aggregates = aggregator.aggregate()
+        if args.output is not None:
+            with args.output.open("w", encoding="utf-8") as f:
+                _write_aggregates_csv(aggregates, f)
+        else:
+            _write_aggregates_csv(aggregates, sys.stdout)
+    else:
+        if args.output is not None:
+            with args.output.open("w", encoding="utf-8") as f:
+                _write_scores_csv(scores, f)
+        else:
+            _write_scores_csv(scores, sys.stdout)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from kurenai.__main__ import main
+
+
+def _write_lines(path: Path, lines: list[str]) -> None:
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+class TestMainScoresCsv:
+    """--use-aggregator を指定しない場合はレコードごとのスコアを出力する。"""
+
+    def test_writes_per_record_scores_to_output_file(
+        self, tmp_path: Path
+    ) -> None:
+        target_file = tmp_path / "targets.txt"
+        prediction_file = tmp_path / "predictions.txt"
+        output_file = tmp_path / "scores.csv"
+
+        _write_lines(target_file, ["one two three four", "testing one two"])
+        _write_lines(prediction_file, ["four three two one", "testing"])
+
+        exit_code = main(
+            [
+                "--rouge-types",
+                "rouge1,rougeL",
+                "--target-file",
+                str(target_file),
+                "--prediction-file",
+                str(prediction_file),
+                "--output",
+                str(output_file),
+            ]
+        )
+
+        assert exit_code == 0
+        # rouge1 (record0): 全単語一致だが順序無視なので precision=recall=1.0
+        # rougeL (record0): 完全に逆順のため LCS は1語のみ -> 0.25
+        # rouge1/rougeL (record1): "testing" のみ一致 -> precision=1.0,
+        # recall=1/3, fscore=0.5 (LCSも1語のみで同値)
+        expected = (
+            "id,rouge1-P,rouge1-R,rouge1-F,rougeL-P,rougeL-R,rougeL-F\n"
+            "0,1.000000,1.000000,1.000000,0.250000,0.250000,0.250000\n"
+            "1,1.000000,0.333333,0.500000,1.000000,0.333333,0.500000\n"
+        )
+        assert output_file.read_text(encoding="utf-8") == expected
+
+    def test_writes_per_record_scores_to_stdout(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        target_file = tmp_path / "targets.txt"
+        prediction_file = tmp_path / "predictions.txt"
+
+        _write_lines(target_file, ["testing one two"])
+        _write_lines(prediction_file, ["testing"])
+
+        exit_code = main(
+            [
+                "--rouge-types",
+                "rouge1",
+                "--target-file",
+                str(target_file),
+                "--prediction-file",
+                str(prediction_file),
+            ]
+        )
+
+        assert exit_code == 0
+        expected = (
+            "id,rouge1-P,rouge1-R,rouge1-F\n0,1.000000,0.333333,0.500000\n"
+        )
+        assert capsys.readouterr().out == expected
+
+
+class TestMainAggregatedScoresCsv:
+    """--use-aggregator を指定した場合は AggregateScore を出力する。"""
+
+    def test_writes_aggregate_scores_to_output_file(
+        self, tmp_path: Path
+    ) -> None:
+        target_file = tmp_path / "targets.txt"
+        prediction_file = tmp_path / "predictions.txt"
+        output_file = tmp_path / "scores.csv"
+
+        # 全レコードが同一の入力なので、ブートストラップ再抽出しても
+        # low/mid/high は常に同じ値になり、決定的に検証できる。
+        # rouge1: target="テスト いち に", prediction="テスト に"
+        # -> precision=2/2=1.0, recall=2/3, fscore=0.8
+        _write_lines(target_file, ["テスト いち に"] * 3)
+        _write_lines(prediction_file, ["テスト に"] * 3)
+
+        exit_code = main(
+            [
+                "--rouge-types",
+                "rouge1",
+                "--target-file",
+                str(target_file),
+                "--prediction-file",
+                str(prediction_file),
+                "--use-aggregator",
+                "--output",
+                str(output_file),
+            ]
+        )
+
+        assert exit_code == 0
+        expected = (
+            "score_type,low,mid,high\n"
+            "rouge1-R,0.666667,0.666667,0.666667\n"
+            "rouge1-P,1.000000,1.000000,1.000000\n"
+            "rouge1-F,0.800000,0.800000,0.800000\n"
+        )
+        assert output_file.read_text(encoding="utf-8") == expected
+
+
+class TestMainErrors:
+    def test_mismatched_line_count_is_an_error(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        target_file = tmp_path / "targets.txt"
+        prediction_file = tmp_path / "predictions.txt"
+
+        _write_lines(target_file, ["one", "two"])
+        _write_lines(prediction_file, ["one", "two", "three"])
+
+        exit_code = main(
+            [
+                "--target-file",
+                str(target_file),
+                "--prediction-file",
+                str(prediction_file),
+            ]
+        )
+
+        assert exit_code != 0
+        assert "same number of lines" in capsys.readouterr().err
+
+    def test_invalid_rouge_type_is_an_error(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        target_file = tmp_path / "targets.txt"
+        prediction_file = tmp_path / "predictions.txt"
+
+        _write_lines(target_file, ["one"])
+        _write_lines(prediction_file, ["one"])
+
+        exit_code = main(
+            [
+                "--rouge-types",
+                "not-a-real-rouge-type",
+                "--target-file",
+                str(target_file),
+                "--prediction-file",
+                str(prediction_file),
+            ]
+        )
+
+        assert exit_code != 0
+        assert "invalid rouge type" in capsys.readouterr().err
+
+
+class TestMainSubprocess:
+    """python -m kurenai として起動できることを確認する。"""
+
+    def test_can_be_invoked_as_a_module(self, tmp_path: Path) -> None:
+        target_file = tmp_path / "targets.txt"
+        prediction_file = tmp_path / "predictions.txt"
+
+        _write_lines(target_file, ["testing one two"])
+        _write_lines(prediction_file, ["testing"])
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "kurenai",
+                "--rouge-types",
+                "rouge1",
+                "--target-file",
+                str(target_file),
+                "--prediction-file",
+                str(prediction_file),
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+        expected = (
+            "id,rouge1-P,rouge1-R,rouge1-F\n0,1.000000,0.333333,0.500000\n"
+        )
+        assert result.stdout == expected


### PR DESCRIPTION
## 概要

`python -m kurenai` として起動できるCLIを実装しました（実装計画 3-1）。`--target-file` / `--prediction-file` に渡した改行区切りテキストファイル同士でROUGEスコアを計算し、CSV形式で出力します。追加の依存（absl等）は導入せず、標準ライブラリの `argparse` のみで実装しています。

## 使用例

```
$ python -m kurenai --rouge-types rouge1,rougeL \
    --target-file targets.txt --prediction-file predictions.txt
id,rouge1-P,rouge1-R,rouge1-F,rougeL-P,rougeL-R,rougeL-F
0,1.000000,0.666667,0.800000,1.000000,0.666667,0.800000
1,1.000000,0.333333,0.500000,1.000000,0.333333,0.500000
```

集計あり（`--use-aggregator`）:

```
$ python -m kurenai --rouge-types rouge1 \
    --target-file targets.txt --prediction-file predictions.txt \
    --use-aggregator
score_type,low,mid,high
rouge1-R,0.333333,0.500000,0.666667
rouge1-P,1.000000,1.000000,1.000000
rouge1-F,0.500000,0.650000,0.800000
```

`--output` を指定するとファイルに、指定しない場合は標準出力に同じCSVを出力します。

## 本家 `rouge_score/io.py` との対応

- `--use-aggregator` なし: `_write_scores_to_csv` と同じ列構成（`id,{type}-P,{type}-R,{type}-F,...`）
- `--use-aggregator` あり: `_write_aggregates_to_csv` と同じ列構成（`score_type,low,mid,high`、各 rouge_type ごとに `-R` → `-P` → `-F` の3行）
- `--rouge-types` の妥当な値は `typing.get_args(kurenai.rouge_scorer.RougeType)` から動的に取得しており、ハードコードしていません（将来 `rougeLsum` が追加された際も自動で追従します）
- ターゲット/予測ファイルの行数が一致しない場合は、本家の `ValueError` 相当のわかりやすいエラーメッセージを標準エラー出力に出し、非0の終了コードを返します
- `kurenai.scoring`（本PRの依存元である #5 で追加）経由で `BootstrapAggregator` 等を利用しており、`rouge_score.scoring` を直接importしていません

## tokenizer オプションを見送った理由

本家CLIにある `--use_stemmer` や将来的な日本語トークナイザ切り替えオプションは、フェーズ2で日本語トークナイザを導入してから対応する予定のため、本PRでは実装していません。現状は `kurenai.rouge_scorer.RougeScorer` が常に `AllCharacterSupportTokenizer` を使用します。

## 依存PR

本PRは #5 の上にスタックしています（base: `feature/scoring-reexport`）。#5 がマージされると、GitHub上でこのPRのbaseは自動的に `main` に付け替わります。

## テスト

`tests/test_main.py` を追加し、以下を検証しています。

- 集計あり/なし両方でのE2E CSV出力内容（ヘッダ・行数・値、手計算で期待値を用意）
- target/predictionファイルの行数不一致時にエラーになること
- 不正な rouge type 指定時にエラーになること
- `subprocess` 経由で `python -m kurenai` として起動できること（`sys.executable` を使用）

`task test`（format → pytest --doctest-modules → flake8 + mypy）はすべてパスしています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)