### PR TITLE
Make constructor compatible with rouge-score

### DIFF
--- a/src/kurenai/rouge_scorer.py
+++ b/src/kurenai/rouge_scorer.py
@@ -5,6 +5,7 @@ from typing import Literal, TypedDict
 
 from rouge_score.rouge_scorer import RougeScorer as OriginalRougeScorer
 from rouge_score.scoring import BaseScorer, Score
+from rouge_score.tokenizers import Tokenizer
 
 from kurenai.tokenizers import AllCharacterSupportTokenizer
 
@@ -46,7 +47,13 @@ class RougeScorer(BaseScorer):
                               "The quick brown dog jumps on the log.")
     """
 
-    def __init__(self, rouge_types: Iterable[RougeType]) -> None:
+    def __init__(
+        self,
+        rouge_types: Iterable[RougeType],
+        use_stemmer: bool = False,
+        split_summaries: bool = False,
+        tokenizer: Tokenizer | None = None,
+    ) -> None:
         """Initializes a new RougeScorer.
 
         Valid rouge types that can be computed are:
@@ -58,9 +65,34 @@ class RougeScorer(BaseScorer):
 
         Args:
             rouge_types: An iterable of rouge types to calculate.
+            use_stemmer: Bool indicating whether the Porter stemmer should
+                be used to strip word suffixes to improve matching. This is
+                honored by kurenai's own default tokenizer
+                (AllCharacterSupportTokenizer), which only stems ASCII
+                alphanumeric tokens longer than 3 characters and leaves
+                non-ASCII tokens (e.g. Japanese) untouched. Unlike
+                rouge-score's original RougeScorer, this value is *not*
+                forwarded to rouge-score's DefaultTokenizer, because that
+                tokenizer drops non-ASCII characters. If a custom
+                ``tokenizer`` is given, this arg has no effect on it -- the
+                same as how rouge-score's use_stemmer only affects its
+                DefaultTokenizer.
+            split_summaries: Whether to add newlines between sentences for
+                rougeLsum. This is passed through to rouge-score as-is.
+                rouge-score splits sentences with nltk.sent_tokenize, which
+                assumes English text, so this option is only reliable for
+                English summaries.
+            tokenizer: Tokenizer object which has a tokenize() method. When
+                omitted, kurenai's AllCharacterSupportTokenizer(use_stemmer=
+                use_stemmer) is used so that non-ASCII text keeps working by
+                default.
         """
+        if tokenizer is None:
+            tokenizer = AllCharacterSupportTokenizer(use_stemmer=use_stemmer)
         self._scorer = OriginalRougeScorer(
-            list(rouge_types), tokenizer=AllCharacterSupportTokenizer()
+            list(rouge_types),
+            split_summaries=split_summaries,
+            tokenizer=tokenizer,
         )
 
     def score(self, target: str, prediction: str) -> RougeScoreDict:

--- a/src/kurenai/rouge_scorer.py
+++ b/src/kurenai/rouge_scorer.py
@@ -70,13 +70,17 @@ class RougeScorer(BaseScorer):
                 honored by kurenai's own default tokenizer
                 (AllCharacterSupportTokenizer), which only stems ASCII
                 alphanumeric tokens longer than 3 characters and leaves
-                non-ASCII tokens (e.g. Japanese) untouched. Unlike
-                rouge-score's original RougeScorer, this value is *not*
-                forwarded to rouge-score's DefaultTokenizer, because that
-                tokenizer drops non-ASCII characters. If a custom
-                ``tokenizer`` is given, this arg has no effect on it -- the
-                same as how rouge-score's use_stemmer only affects its
-                DefaultTokenizer.
+                non-ASCII tokens (e.g. Japanese) untouched. Because kurenai
+                never deletes or rewrites characters, tokens that still
+                carry punctuation (e.g. "dogs.") are not stemmed; unlike
+                rouge-score, no non-alphanumeric characters are stripped
+                before stemming, so pass in pre-tokenized, space-separated
+                text for the best results. Unlike rouge-score's original
+                RougeScorer, this value is *not* forwarded to rouge-score's
+                DefaultTokenizer, because that tokenizer drops non-ASCII
+                characters. If a custom ``tokenizer`` is given, this arg
+                has no effect on it -- the same as how rouge-score's
+                use_stemmer only affects its DefaultTokenizer.
             split_summaries: Whether to add newlines between sentences for
                 rougeLsum. This is passed through to rouge-score as-is.
                 rouge-score splits sentences with nltk.sent_tokenize, which

--- a/src/kurenai/tokenizers.py
+++ b/src/kurenai/tokenizers.py
@@ -25,6 +25,22 @@ class AllCharacterSupportTokenizer(Tokenizer):
     ...     "いぬ が はしる"
     ... )
     ['いぬ', 'が', 'はしる']
+
+    Tokens that still carry punctuation (e.g. "dogs.") are *not* stemmed,
+    because kurenai never deletes or rewrites characters -- it only splits
+    on whitespace. This tokenizer therefore expects input that is already
+    segmented into words, with punctuation split off into its own tokens
+    (as pre-tokenized, space-separated input would look). rouge-score's
+    own tokenizer instead replaces non-alphanumeric characters with spaces
+    before stemming, so scores for raw, punctuated English sentences may
+    differ from rouge-score's. Splitting punctuation off is a tokenizer's
+    job; a Japanese-aware tokenizer that does this is planned for a later
+    phase.
+
+    >>> AllCharacterSupportTokenizer(use_stemmer=True).tokenize(
+    ...     "The dogs. are running."
+    ... )
+    ['the', 'dogs.', 'are', 'running.']
     """
 
     def __init__(self, use_stemmer: bool = False) -> None:

--- a/src/kurenai/tokenizers.py
+++ b/src/kurenai/tokenizers.py
@@ -1,14 +1,44 @@
 from __future__ import annotations
 
+import re
+
+from nltk.stem import porter
 from rouge_score.tokenize import SPACES_RE
 from rouge_score.tokenizers import Tokenizer
+
+# ref: https://github.com/google-research/google-research/blob/master/rouge/tokenize.py  # NOQA: E501
+# rouge-score only stems tokens that consist solely of ASCII
+# alphanumeric characters and are longer than 3 characters; this mirrors
+# that rule so non-ASCII (e.g. Japanese) tokens are never touched.
+STEMMABLE_TOKEN_RE = re.compile(r"^[a-z0-9]+$")
 
 
 class AllCharacterSupportTokenizer(Tokenizer):
     """
     >>> AllCharacterSupportTokenizer().tokenize("いぬ ねこ")
     ['いぬ', 'ねこ']
+    >>> AllCharacterSupportTokenizer(use_stemmer=True).tokenize(
+    ...     "The dogs are running"
+    ... )
+    ['the', 'dog', 'are', 'run']
+    >>> AllCharacterSupportTokenizer(use_stemmer=True).tokenize(
+    ...     "いぬ が はしる"
+    ... )
+    ['いぬ', 'が', 'はしる']
     """
 
+    def __init__(self, use_stemmer: bool = False) -> None:
+        self._use_stemmer = use_stemmer
+        self._stemmer = porter.PorterStemmer() if use_stemmer else None
+
     def tokenize(self, text: str) -> list[str]:
-        return SPACES_RE.split(text.lower())
+        tokens = SPACES_RE.split(text.lower())
+        if self._stemmer is None:
+            return tokens
+        return [self._maybe_stem(token) for token in tokens]
+
+    def _maybe_stem(self, token: str) -> str:
+        assert self._stemmer is not None
+        if len(token) > 3 and STEMMABLE_TOKEN_RE.match(token):
+            return str(self._stemmer.stem(token))
+        return token

--- a/tests/test_kurenai.py
+++ b/tests/test_kurenai.py
@@ -1,5 +1,6 @@
 from rouge_score.rouge_scorer import RougeScorer as OriginalRougeScorer
 from rouge_score.scoring import BaseScorer, Score
+from rouge_score.tokenizers import Tokenizer
 
 from kurenai.rouge_scorer import RougeScorer
 
@@ -152,3 +153,71 @@ class TestRougeScorer:
                     "rougeL": Score(precision_L, recall_L, fscore_L),
                 }
                 assert actual == expected
+
+    class TestConstructorCompat:
+        def test_use_stemmer_matches_original_rouge_score(self) -> None:
+            # "dogs"/"dog", "running"/"runs" are different tokens unless
+            # stemmed; use_stemmer=True should make kurenai and rouge-score
+            # agree on purely ASCII text.
+            target = "The dogs are running in the park"
+            prediction = "The dog runs in the park"
+
+            sut = RougeScorer(["rouge1", "rougeL"], use_stemmer=True)
+            original = OriginalRougeScorer(
+                ["rouge1", "rougeL"], use_stemmer=True
+            )
+
+            assert sut.score(target, prediction) == original.score(
+                target, prediction
+            )
+
+        def test_use_stemmer_true_changes_ascii_score(self) -> None:
+            # Without stemming, "dogs" != "dog" and "running" != "runs", so
+            # the score should differ from the stemmed version above.
+            target = "The dogs are running in the park"
+            prediction = "The dog runs in the park"
+
+            without_stemmer = RougeScorer(["rouge1"]).score(target, prediction)
+            with_stemmer = RougeScorer(["rouge1"], use_stemmer=True).score(
+                target, prediction
+            )
+
+            assert without_stemmer != with_stemmer
+
+        def test_use_stemmer_true_keeps_non_ascii_score_unchanged(
+            self,
+        ) -> None:
+            target = "テスト いち に"
+            prediction = "テスト に"
+
+            without_stemmer = RougeScorer(["rouge1"]).score(target, prediction)
+            with_stemmer = RougeScorer(["rouge1"], use_stemmer=True).score(
+                target, prediction
+            )
+
+            assert without_stemmer == with_stemmer
+
+        def test_custom_tokenizer_is_used(self) -> None:
+            class UpperCaseSplitTokenizer(Tokenizer):
+                def tokenize(self, text: str) -> list[str]:
+                    return text.split()
+
+            tokenizer = UpperCaseSplitTokenizer()
+            sut = RougeScorer(["rouge1"], tokenizer=tokenizer)
+
+            assert sut._scorer._tokenizer is tokenizer
+            # "Testing" (custom tokenizer keeps the original case) only
+            # matches itself, not the lowercased default tokenization.
+            actual = sut.score("Testing one two", "testing")
+            expected = {"rouge1": Score(0.0, 0.0, 0.0)}
+            assert actual == expected
+
+        def test_split_summaries_is_passed_to_original_scorer(self) -> None:
+            sut = RougeScorer(["rougeLsum"], split_summaries=True)
+
+            assert sut._scorer._split_summaries is True
+
+        def test_split_summaries_defaults_to_false(self) -> None:
+            sut = RougeScorer(["rougeLsum"])
+
+            assert sut._scorer._split_summaries is False

--- a/tests/test_tokenizers.py
+++ b/tests/test_tokenizers.py
@@ -1,0 +1,56 @@
+from kurenai.tokenizers import AllCharacterSupportTokenizer
+
+
+class TestAllCharacterSupportTokenizer:
+    def test_tokenize_without_stemmer(self) -> None:
+        sut = AllCharacterSupportTokenizer()
+
+        actual = sut.tokenize("いぬ ねこ")
+
+        assert actual == ["いぬ", "ねこ"]
+
+    class TestWithStemmer:
+        def test_tokens_longer_than_3_chars_are_stemmed(self) -> None:
+            sut = AllCharacterSupportTokenizer(use_stemmer=True)
+
+            # "dogs" (4 chars) and "running" (7 chars) are stemmed;
+            # rouge-score only stems tokens of length > 3.
+            actual = sut.tokenize("The dogs are running")
+
+            assert actual == ["the", "dog", "are", "run"]
+
+        def test_tokens_of_3_chars_or_fewer_are_not_stemmed(self) -> None:
+            sut = AllCharacterSupportTokenizer(use_stemmer=True)
+
+            # "run" is 3 chars, at or below rouge-score's "len > 3"
+            # threshold for stemming, so it is left untouched.
+            actual = sut.tokenize("cat run")
+
+            assert actual == ["cat", "run"]
+
+        def test_non_ascii_tokens_are_not_stemmed(self) -> None:
+            sut = AllCharacterSupportTokenizer(use_stemmer=True)
+
+            actual = sut.tokenize("いぬ が はしる")
+
+            assert actual == ["いぬ", "が", "はしる"]
+
+        def test_alnum_token_with_digits_can_be_stemmed(self) -> None:
+            sut = AllCharacterSupportTokenizer(use_stemmer=True)
+
+            # "2dogs" (5 chars) is made of lowercase letters and digits
+            # only, so it matches rouge-score's [a-z0-9]+ token pattern
+            # and gets stemmed like a pure-alphabetic token would.
+            actual = sut.tokenize("2dogs")
+
+            assert actual == ["2dog"]
+
+        def test_token_with_non_alnum_char_is_not_stemmed(self) -> None:
+            sut = AllCharacterSupportTokenizer(use_stemmer=True)
+
+            # "run_ning" contains an underscore, so it does not match
+            # rouge-score's [a-z0-9]+ token pattern and is left untouched,
+            # even though it is longer than 3 characters.
+            actual = sut.tokenize("run_ning")
+
+            assert actual == ["run_ning"]

--- a/tests/test_tokenizers.py
+++ b/tests/test_tokenizers.py
@@ -54,3 +54,17 @@ class TestAllCharacterSupportTokenizer:
             actual = sut.tokenize("run_ning")
 
             assert actual == ["run_ning"]
+
+        def test_punctuated_token_is_not_stemmed(self) -> None:
+            sut = AllCharacterSupportTokenizer(use_stemmer=True)
+
+            # "dogs." keeps its trailing period because this tokenizer only
+            # splits on whitespace and never deletes or rewrites
+            # characters. That period makes the token fail rouge-score's
+            # [a-z0-9]+ pattern, so it is left unstemmed -- unlike
+            # rouge-score, which strips non-alphanumeric characters before
+            # stemming. This is expected: kurenai's tokenizer is designed
+            # for pre-tokenized, space-separated input.
+            actual = sut.tokenize("The dogs. are running.")
+
+            assert actual == ["the", "dogs.", "are", "running."]


### PR DESCRIPTION
## 概要

`RougeScorer.__init__` に本家 rouge-score の `OriginalRougeScorer` と同じ引数 `use_stemmer` / `split_summaries` / `tokenizer` を追加し、コンストラクタのシグネチャを本家互換にします。既存の `RougeScorer(["rouge1"])` のようなデフォルト挙動は変更していません。

## 設計判断

- **`use_stemmer` を本家に渡さない理由**: 本家の `use_stemmer` は `OriginalRougeScorer` 内部で `tokenizers.DefaultTokenizer(use_stemmer)` を生成するために使われます。しかし `DefaultTokenizer` は非ASCII文字を除去してしまうため、kurenai の非ASCII対応が壊れてしまいます。そこで kurenai は `use_stemmer` を本家には渡さず、kurenai 自身の `AllCharacterSupportTokenizer(use_stemmer=use_stemmer)` に解釈させ、それを `tokenizer=` として本家スコアラーに渡します。
- **`AllCharacterSupportTokenizer` の stem 対象**: 本家 `rouge_score/tokenize.py` の `tokenize()` は「`len(token) > 3` のトークンだけ `PorterStemmer().stem()` を適用する」という挙動です。これを踏襲し、kurenai 側でも `[a-z0-9]+` にマッチし、かつ4文字以上のトークンだけを stem 対象にしました（日本語や記号混じりのトークンには一切触れません）。
- **`tokenizer` 指定時の意味論**: `tokenizer` を明示的に渡した場合、`use_stemmer` はそのカスタム tokenizer には作用しません。これは本家の `use_stemmer` が `DefaultTokenizer` にしか作用しないのと同じ意味論です（本家も `tokenizer` が渡されると `use_stemmer` を無視します）。
- **`split_summaries`**: そのまま本家コンストラクタに渡すだけです。本家は `nltk.sent_tokenize` を使うため英語前提の機能である旨を docstring に明記しました。ネットワークが必要な nltk データ（punkt 等）をダウンロードする end-to-end テストは CI がネットワーク依存になってしまうため避け、`_scorer._split_summaries` の内部属性確認に留めています。

## テスト内容

- `tests/test_kurenai.py` に `TestRougeScorer.TestConstructorCompat` を追加
  - 英語の語形変化を含む文（"dogs"/"dog", "running"/"runs"）で `use_stemmer=True` としたとき、kurenai と本家 `OriginalRougeScorer` のスコアが一致すること
  - 同じ文で `use_stemmer=True` と `False` でスコアが実際に変わること（stem が効いていることの確認）
  - `use_stemmer=True` でも日本語のスコアは変わらないこと
  - カスタム `tokenizer` を渡すとそれが使われること（`_scorer._tokenizer is tokenizer` の確認と、大文字小文字を区別する挙動でのスコア確認）
  - `split_summaries=True/False` がコンストラクタで受け付けられ、本家スコアラーの内部属性に伝わること
- `tests/test_tokenizers.py`（新規）に `AllCharacterSupportTokenizer(use_stemmer=True).tokenize()` の単体テストを追加
  - 4文字超の英単語は stem される／3文字以下は stem されない
  - 日本語トークンは一切変化しない
  - 数字混じりの `[a-z0-9]+` トークンは stem 対象、記号混じりトークンは対象外（本家の `VALID_TOKEN_RE` 相当の判定を踏襲）
- `src/kurenai/tokenizers.py` の doctest にも `use_stemmer=True` の例（英語が stem され日本語が変わらない例）を追加

`task test`（format → pytest --doctest-modules → flake8 + mypy）はすべて成功しています。

## 依存PR

このPRは #6（rougeLsum サポート）の上にスタックしています。base は `feature/rouge-lsum` です。#6 がマージされると、base は自動的に `main` に付け替わります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)